### PR TITLE
Add Tox Testing

### DIFF
--- a/ostiapi/__init__.py
+++ b/ostiapi/__init__.py
@@ -86,7 +86,7 @@ def reserve(data, username=None, password=None):
     
     data['set_reserved'] = "true"
 
-    return post(data, username, password);
+    return post(data, username, password)
 
 
 def post(data, username=None, password=None):
@@ -128,7 +128,7 @@ def post(data, username=None, password=None):
     records.append(data)
 
     # post XML to ELINK API
-    elink = requests.post(url + '2416api',
+    elink = requests.post(this.url + '2416api',
                           data=datatoxml(records),
                           auth=(username, password))
 
@@ -191,7 +191,7 @@ def get(id, username=None, password=None):
     :param password: the ELINK account password
     :return: a dict containing the record metadata if found
     """
-    elink = requests.get(url + '2416api?osti_id=' + str(id),
+    elink = requests.get(this.url + '2416api?osti_id=' + str(id),
                          auth=(username, password))
 
     if elink.status_code == 200:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description_content_type='text/markdown',
     author='Neal Ensor',
     author_email='EnsorN@osti.gov',
-    packages=find_packages(),
+    packages=find_packages(include=['ostiapi']),
     install_requires=[
         'requests',
         'dicttoxml'

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+include = */site-packages/ostiapi/*
+
+[report]
+include = */site-packages/ostiapi/*

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+"""
+Test Module
+
+Contains all the tests to verify functionality of the
+OSTI Client API. Each set of tests should be contained
+in their own `_test.py` module.
+"""

--- a/tests/ostiapi_test.py
+++ b/tests/ostiapi_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Test the example module."""
+from os import getenv
+from unittest import TestCase
+import ostiapi
+
+
+class TestOstiApi(TestCase):
+    """Test the basic functionality."""
+
+    username = getenv('OSTI_USERNAME', 'my-osti-account')
+    password = getenv('OSTI_PASSWORD', 'my-osti-password')
+
+    def setup_method(self, *_args, **kwargs):
+        """Put the module into testing mode."""
+        print("Turn ostiapi into test mode.")
+        ostiapi.testmode()
+
+    def _setup_reserve(self):
+        """Setup an example reservation."""
+        return ostiapi.reserve(
+            {
+                'title':'My upcoming dataset',
+                'accession_num':'sample-ds-0001'
+            },
+            self.username,
+            self.password
+        )
+
+    def test_reserve(self):
+        """Test the reserve method in the ostiapi module."""
+        data = self._setup_reserve()
+        self.assertTrue('record' in data)
+        self.assertTrue('title' in data['record'])
+        self.assertEqual(data['record']['title'], 'My upcoming dataset')
+        self.assertEqual(data['record']['status'], 'SUCCESS')
+        self.assertEqual(data['record']['doi_status'], 'RESERVED')
+        self.assertFalse(data['record']['status_message'], 'Status message should be none')
+
+    def test_get(self):
+        """Test the get method in the ostiapi module."""
+        data = ostiapi.get(
+            self._setup_reserve()['record']['osti_id'],
+            self.username,
+            self.password
+        )
+        self.assertTrue('record' in data)
+        self.assertTrue('title' in data['record'])
+        self.assertEqual(data['record']['title'], 'My upcoming dataset')
+        self.assertEqual(data['record']['status'], 'SUCCESS')
+        self.assertEqual(data['record']['doi_status'], 'RESERVED')
+        self.assertFalse(data['record']['status_message'], 'Status message should be none')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+envlist = py36,py37,py38
+
+[testenv]
+deps =
+    coverage
+    pytest
+    pytest-cov
+setenv =
+  OSTI_USERNAME = {env:OSTI_USERNAME:tox-default-username}
+  OSTI_PASSWORD = {env:OSTI_PASSWORD:tox-default-password}
+commands = pytest -x --cov --cov-append --cov-report=term-missing
+changedir = tests
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report -m --fail-under 100
+    coverage html
+changedir = tests
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+changedir = tests


### PR DESCRIPTION
This adds testing to the code with some tests outlined in the
README.md file. To execute the tests export the OSTI username and
password into the environment and run tox.

```
$ pip3 install tox
$ export OSTI_USERNAME=my-osti-username
$ export OSTI_PASSWORD=my-osti-password
$ tox
```

Signed-off-by: David Brown <dmlb2000@gmail.com>