### PR TITLE
Add Optional Site Code to Testing

### DIFF
--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-include = */site-packages/ostiapi/*
+include = */ostiapi/__init__.py
 
 [report]
-include = */site-packages/ostiapi/*
+include = */ostiapi/__init__.py

--- a/tests/ostiapi_test.py
+++ b/tests/ostiapi_test.py
@@ -11,6 +11,7 @@ class TestOstiApi(TestCase):
 
     username = getenv('OSTI_USERNAME', 'my-osti-account')
     password = getenv('OSTI_PASSWORD', 'my-osti-password')
+    site_input_code = getenv('OSTI_SITE_CODE', 'my-osti-site-code')
 
     def setup_method(self, *_args, **kwargs):
         """Put the module into testing mode."""
@@ -22,7 +23,8 @@ class TestOstiApi(TestCase):
         return ostiapi.reserve(
             {
                 'title':'My upcoming dataset',
-                'accession_num':'sample-ds-0001'
+                'accession_num':'sample-ds-0001',
+                'site_input_code': self.site_input_code
             },
             self.username,
             self.password
@@ -40,14 +42,14 @@ class TestOstiApi(TestCase):
 
     def test_get(self):
         """Test the get method in the ostiapi module."""
+        reserve_result = self._setup_reserve()
         data = ostiapi.get(
-            self._setup_reserve()['record']['osti_id'],
+            reserve_result['record']['osti_id'],
             self.username,
             self.password
         )
         self.assertTrue('record' in data)
         self.assertTrue('title' in data['record'])
         self.assertEqual(data['record']['title'], 'My upcoming dataset')
-        self.assertEqual(data['record']['status'], 'SUCCESS')
-        self.assertEqual(data['record']['doi_status'], 'RESERVED')
-        self.assertFalse(data['record']['status_message'], 'Status message should be none')
+        self.assertEqual(data['record']['doi_status'], 'PENDING')
+        self.assertEqual(data['record']['accession_num'], 'sample-ds-0001')

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
 setenv =
   OSTI_USERNAME = {env:OSTI_USERNAME:tox-default-username}
   OSTI_PASSWORD = {env:OSTI_PASSWORD:tox-default-password}
+  OSTI_SITE_CODE = {env:OSTI_SITE_CODE:tox-default-sitecode}
 commands = pytest -x --cov --cov-append --cov-report=term-missing
 changedir = tests
 


### PR DESCRIPTION
This refines the testing to include optional site code.

For the account I was using to perform testing a site code was required. So I added the option to pass (by environment) the site code to the testing suite.

I did get testing to complete successfully at this point.

Signed-off-by: David Brown <dmlb2000@gmail.com>