### PR TITLE
Bump version of dicttoxml to support python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 certifi==2021.5.30
 charset-normalizer==2.0.6
-dicttoxml==1.7.4
+dicttoxml==1.7.8
 idna==3.2
 requests==2.26.0
 urllib3==1.26.7


### PR DESCRIPTION
Closes #9 

This fix adopts the latest version of `dicttoxml`, which provides both python 3.10 and lower support.

If this can be merged soon, this would be great.

Some manual unit testing was conducted and showed that it worked:

```bash
pip install dicttoxml==1.7.8
```

```python
import ostiapi
import json

with open("../pdc-osti/data/osti.json") as f:
    data = json.load(f)

xml_data = ostiapi.datatoxml(data)
```

For reference, `dicttoxml` v1.7.4 will result in the following:
```python
    188 if isinstance(obj, dict):
    189     return convert_dict(obj, ids, parent, attr_type, item_func, cdata)
--> 191 if isinstance(obj, collections.Iterable):
    192     return convert_list(obj, ids, parent, attr_type, item_func, cdata)
    194 raise TypeError('Unsupported data type: %s (%s)' % (obj, type(obj).__name__))

AttributeError: module 'collections' has no attribute 'Iterable'
```